### PR TITLE
feat(react): Add React integration layer with context and hooks

### DIFF
--- a/src/components/TabStateErrorBoundary.tsx
+++ b/src/components/TabStateErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class TabStateErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <div>Something went wrong with tab state.</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/context/TabStateContext.tsx
+++ b/src/context/TabStateContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useTabStateManager } from '../hooks/useTabStateManager';
+import type { StateManagerOptions } from '../types';
+
+interface TabStateContextValue<T> {
+  state: T;
+  setState: (update: Partial<T>) => void;
+  subscribe: (callback: (state: T) => void) => () => void;
+}
+
+const TabStateContext = createContext<TabStateContextValue<any> | null>(null);
+
+interface TabStateProviderProps<T extends Record<string, any>> {
+  children: ReactNode;
+  options: StateManagerOptions<T>;
+}
+
+export function TabStateProvider<T extends Record<string, any>>({ 
+  children, 
+  options 
+}: TabStateProviderProps<T>) {
+  const { getState, setState, subscribe } = useTabStateManager<T>(options);
+
+  const value = {
+    state: getState(),
+    setState,
+    subscribe,
+  };
+
+  return (
+    <TabStateContext.Provider value={value}>
+      {children}
+    </TabStateContext.Provider>
+  );
+}
+
+export function useTabState<T>() {
+  const context = useContext(TabStateContext);
+  if (!context) {
+    throw new Error('useTabState must be used within a TabStateProvider');
+  }
+  return context as TabStateContextValue<T>;
+}

--- a/src/hoc/withTabState.tsx
+++ b/src/hoc/withTabState.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useTabState } from '../context/TabStateContext';
+
+interface WithTabStateProps<T> {
+  tabState: T;
+  setTabState: (update: Partial<T>) => void;
+}
+
+export function withTabState<T, P extends WithTabStateProps<T>>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  return function WithTabStateComponent(
+    props: Omit<P, keyof WithTabStateProps<T>>
+  ) {
+    const { state, setState } = useTabState<T>();
+
+    return (
+      <WrappedComponent
+        {...(props as P)}
+        tabState={state}
+        setTabState={setState}
+      />
+    );
+  };
+}

--- a/src/hooks/useTabEffect.ts
+++ b/src/hooks/useTabEffect.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { useTabState } from '../context/TabStateContext';
+
+export function useTabEffect<T>(
+  effect: (state: T) => void | (() => void),
+  deps: any[] = []
+) {
+  const { state, subscribe } = useTabState<T>();
+  const effectRef = useRef(effect);
+  effectRef.current = effect;
+
+  useEffect(() => {
+    let cleanup: void | (() => void);
+    
+    cleanup = effectRef.current(state);
+
+    const unsubscribe = subscribe((newState) => {
+      if (cleanup) cleanup();
+      cleanup = effectRef.current(newState);
+    });
+
+    return () => {
+      if (cleanup) cleanup();
+      unsubscribe();
+    };
+  }, deps);
+}

--- a/src/hooks/useTabSync.ts
+++ b/src/hooks/useTabSync.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import { useTabState } from '../context/TabStateContext';
+
+export function useTabSync<T, K extends keyof T>(
+  key: K,
+  onChange?: (value: T[K]) => void
+) {
+  const { state, subscribe } = useTabState<T>();
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    const unsubscribe = subscribe((newState) => {
+      if (onChangeRef.current) {
+        onChangeRef.current(newState[key]);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [key, subscribe]);
+
+  return state[key];
+}


### PR DESCRIPTION
This pull request introduces a new context and error boundary for managing tab state in the application. The most important changes include the creation of a `TabStateErrorBoundary` component, a `TabStateContext`, and several hooks and higher-order components (HOCs) for managing and synchronizing tab state.

### Tab State Management:

* [`src/context/TabStateContext.tsx`](diffhunk://#diff-8a20b79e96d7b308adfead42fba3f42df6f579743e25bf2b2b84499c64bdf2baR1-R43): Added `TabStateContext` and `TabStateProvider` for managing tab state, along with the `useTabState` hook to access the context.
* [`src/hooks/useTabEffect.ts`](diffhunk://#diff-29e5def4b8ffaf88aeb8ec40c497cbcc893126f2026785bdd592ae3d3420a181R1-R27): Introduced `useTabEffect` hook to handle side effects based on tab state changes.
* [`src/hooks/useTabSync.ts`](diffhunk://#diff-ecd686bfa2302c18a22cc1f2135fa54f87f5160afd90cefb3bbcab67c1efd510R1-R25): Added `useTabSync` hook to synchronize specific state keys with optional change handlers.

### Error Handling:

* [`src/components/TabStateErrorBoundary.tsx`](diffhunk://#diff-62d144fb770fd3ea219320356af43c489cbc29c1a6f4b32b237631e46d09d29eR1-R33): Created `TabStateErrorBoundary` component to catch and handle errors in tab state management.

### Higher-Order Components:

* [`src/hoc/withTabState.tsx`](diffhunk://#diff-671e8c30deec273da56c0305f21293138dc827a5d652c0a874e6a37b19b7b62fR1-R25): Implemented `withTabState` HOC to inject tab state and state updater into wrapped components.

Closes #5 