### PR TITLE
docs: update README and package.json with comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,150 @@
-# TSDX React w/ Storybook User Guide
+# Tab State Manager
 
-Congrats! You just saved yourself hours of work by bootstrapping this project with TSDX. Let’s get you oriented with what’s here and how to use it.
+A lightweight React library for synchronizing state across browser tabs in real-time.
 
-> This TSDX setup is meant for developing React component libraries (not apps!) that can be published to NPM. If you’re looking to build a React-based app, you should use `create-react-app`, `razzle`, `nextjs`, `gatsby`, or `react-static`.
+[![NPM Version](https://img.shields.io/npm/v/tab-state-manager.svg)](https://www.npmjs.com/package/tab-state-manager)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> If you’re new to TypeScript and React, checkout [this handy cheatsheet](https://github.com/sw-yx/react-typescript-cheatsheet/)
+## Features
 
-## Commands
+- 🔄 Real-time state synchronization across browser tabs
+- 🎯 Type-safe with full TypeScript support
+- ⚡️ Optimized performance with automatic debouncing
+- 🛡️ Built-in error boundary and error handling
+- 📦 Lightweight (<10KB) with zero dependencies
+- 🔌 Flexible hooks-based API
 
-TSDX scaffolds your new library inside `/src`, and also sets up a [Parcel-based](https://parceljs.org) playground for it inside `/example`.
-
-The recommended workflow is to run TSDX in one terminal:
-
-```bash
-npm start # or yarn start
-```
-
-This builds to `/dist` and runs the project in watch mode so any edits you save inside `src` causes a rebuild to `/dist`.
-
-Then run either Storybook or the example playground:
-
-### Storybook
-
-Run inside another terminal:
+## Installation
 
 ```bash
-yarn storybook
+npm install tab-state-manager
+# or
+yarn add tab-state-manager
 ```
 
-This loads the stories from `./stories`.
+## Quick Start
 
-> NOTE: Stories should reference the components as if using the library, similar to the example playground. This means importing from the root project directory. This has been aliased in the tsconfig and the storybook webpack config as a helper.
+```tsx
+import { TabStateProvider, useTabState } from 'tab-state-manager';
 
-### Example
+// Define your state type
+interface AppState {
+  count: number;
+}
 
-Then run the example inside another:
+// Create your component
+function Counter() {
+  const { state, setState } = useTabState<AppState>();
+  
+  return (
+    <button onClick={() => setState({ count: state.count + 1 })}>
+      Count: {state.count}
+    </button>
+  );
+}
 
-```bash
-cd example
-npm i # or yarn to install dependencies
-npm start # or yarn start
-```
-
-The default example imports and live reloads whatever is in `/dist`, so if you are seeing an out of date component, make sure TSDX is running in watch mode like we recommend above. **No symlinking required**, we use [Parcel's aliasing](https://parceljs.org/module_resolution.html#aliases).
-
-To do a one-off build, use `npm run build` or `yarn build`.
-
-To run tests, use `npm test` or `yarn test`.
-
-## Configuration
-
-Code quality is set up for you with `prettier`, `husky`, and `lint-staged`. Adjust the respective fields in `package.json` accordingly.
-
-### Jest
-
-Jest tests are set up to run with `npm test` or `yarn test`.
-
-### Bundle analysis
-
-Calculates the real cost of your library using [size-limit](https://github.com/ai/size-limit) with `npm run size` and visulize it with `npm run analyze`.
-
-#### Setup Files
-
-This is the folder structure we set up for you:
-
-```txt
-/example
-  index.html
-  index.tsx       # test your component here in a demo app
-  package.json
-  tsconfig.json
-/src
-  index.tsx       # EDIT THIS
-/test
-  blah.test.tsx   # EDIT THIS
-/stories
-  Thing.stories.tsx # EDIT THIS
-/.storybook
-  main.js
-  preview.js
-.gitignore
-package.json
-README.md         # EDIT THIS
-tsconfig.json
-```
-
-#### React Testing Library
-
-We do not set up `react-testing-library` for you yet, we welcome contributions and documentation on this.
-
-### Rollup
-
-TSDX uses [Rollup](https://rollupjs.org) as a bundler and generates multiple rollup configs for various module formats and build settings. See [Optimizations](#optimizations) for details.
-
-### TypeScript
-
-`tsconfig.json` is set up to interpret `dom` and `esnext` types, as well as `react` for `jsx`. Adjust according to your needs.
-
-## Continuous Integration
-
-### GitHub Actions
-
-Two actions are added by default:
-
-- `main` which installs deps w/ cache, lints, tests, and builds on all pushes against a Node and OS matrix
-- `size` which comments cost comparison of your library on every pull request using [size-limit](https://github.com/ai/size-limit)
-
-## Optimizations
-
-Please see the main `tsdx` [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
-
-```js
-// ./types/index.d.ts
-declare var __DEV__: boolean;
-
-// inside your code...
-if (__DEV__) {
-  console.log('foo');
+// Wrap your app with the provider
+function App() {
+  return (
+    <TabStateProvider
+      options={{
+        channelName: 'my-app',
+        initialState: { count: 0 }
+      }}
+    >
+      <Counter />
+    </TabStateProvider>
+  );
 }
 ```
 
-You can also choose to install and use [invariant](https://github.com/palmerhq/tsdx#invariant) and [warning](https://github.com/palmerhq/tsdx#warning) functions.
+## Core Concepts
 
-## Module Formats
+- **Tab Synchronization**: State changes are automatically synchronized across all open tabs
+- **Leader Election**: One tab acts as the leader to manage state consistency
+- **Error Handling**: Built-in error boundary and error reporting
+- **Type Safety**: Full TypeScript support for type-safe state management
 
-CJS, ESModules, and UMD module formats are supported.
+## API Reference
 
-The appropriate paths are configured in `package.json` and `dist/index.js` accordingly. Please report if any issues are found.
+### TabStateProvider
 
-## Deploying the Example Playground
-
-The Playground is just a simple [Parcel](https://parceljs.org) app, you can deploy it anywhere you would normally deploy that. Here are some guidelines for **manually** deploying with the Netlify CLI (`npm i -g netlify-cli`):
-
-```bash
-cd example # if not already in the example folder
-npm run build # builds to dist
-netlify deploy # deploy the dist folder
+```tsx
+<TabStateProvider
+  options={{
+    channelName: string;          // Required: Unique channel identifier
+    initialState: T;              // Required: Initial state
+    debounceTime?: number;        // Optional: Debounce delay (default: 100ms)
+    onError?: (error: Error) => void;    // Optional: Error handler
+    onBecomeLeader?: () => void;         // Optional: Leader election callback
+    onResignLeader?: () => void;         // Optional: Leader resignation callback
+  }}
+>
+  {children}
+</TabStateProvider>
 ```
 
-Alternatively, if you already have a git repo connected, you can set up continuous deployment with Netlify:
+### Hooks
 
-```bash
-netlify init
-# build command: yarn build && cd example && yarn && yarn build
-# directory to deploy: example/dist
-# pick yes for netlify.toml
+#### useTabState
+```tsx
+const { state, setState, subscribe } = useTabState<T>();
 ```
 
-## Named Exports
-
-Per Palmer Group guidelines, [always use named exports.](https://github.com/palmerhq/typescript#exports) Code split inside your React app instead of your React library.
-
-## Including Styles
-
-There are many ways to ship styles, including with CSS-in-JS. TSDX has no opinion on this, configure how you like.
-
-For vanilla CSS, you can include it at the root directory and add it to the `files` section in your `package.json`, so that it can be imported separately by your users and run through their bundler's loader.
-
-## Publishing to NPM
-
-We recommend using [np](https://github.com/sindresorhus/np).
-
-## Usage with Lerna
-
-When creating a new package with TSDX within a project set up with Lerna, you might encounter a `Cannot resolve dependency` error when trying to run the `example` project. To fix that you will need to make changes to the `package.json` file _inside the `example` directory_.
-
-The problem is that due to the nature of how dependencies are installed in Lerna projects, the aliases in the example project's `package.json` might not point to the right place, as those dependencies might have been installed in the root of your Lerna project.
-
-Change the `alias` to point to where those packages are actually installed. This depends on the directory structure of your Lerna project, so the actual path might be different from the diff below.
-
-```diff
-   "alias": {
--    "react": "../node_modules/react",
--    "react-dom": "../node_modules/react-dom"
-+    "react": "../../../node_modules/react",
-+    "react-dom": "../../../node_modules/react-dom"
-   },
+#### useTabEffect
+```tsx
+useTabEffect<T>((state) => {
+  // Effect logic
+  return () => {
+    // Cleanup logic
+  };
+}, [dependencies]);
 ```
 
-An alternative to fixing this problem would be to remove aliases altogether and define the dependencies referenced as aliases as dev dependencies instead. [However, that might cause other problems.](https://github.com/palmerhq/tsdx/issues/64)
+#### useTabSync
+```tsx
+const value = useTabSync<T, K>(
+  'propertyKey',
+  (newValue) => {
+    // Handle changes
+  }
+);
+```
+
+## Error Handling
+
+```tsx
+<TabStateErrorBoundary
+  fallback={<ErrorComponent />}
+  onError={(error, errorInfo) => {
+    console.error(error);
+  }}
+>
+  <YourComponent />
+</TabStateErrorBoundary>
+```
+
+## Best Practices
+
+1. **State Structure**
+   - Keep state flat when possible
+   - Use normalized data structures for complex state
+   - Avoid storing derived state
+
+2. **Performance**
+   - Use appropriate debounce times for your use case
+   - Implement selective synchronization with useTabSync
+   - Monitor state size and update frequency
+
+3. **Error Handling**
+   - Always implement error boundaries
+   - Provide fallback UI for error states
+   - Log errors appropriately
+
+## Browser Support
+
+Supports all modern browsers that implement the [BroadcastChannel API](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
+
+## Contributing
+
+Contributions are welcome! Please read our [contributing guidelines](CONTRIBUTING.md) first.

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "react-app-polyfill": "^1.0.0"
+    "react-app-polyfill": "1.0.0"
   },
   "alias": {
     "react": "../node_modules/react",
@@ -16,9 +16,9 @@
     "scheduler/tracing": "../node_modules/scheduler/tracing-profiling"
   },
   "devDependencies": {
-    "@types/react": "^16.9.11",
-    "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
-    "typescript": "^3.4.5"
+    "@types/react": "16.9.11",
+    "@types/react-dom": "16.8.4",
+    "parcel": "1.12.3",
+    "typescript": "3.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,18 +8,19 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test --passWithNoTests",
-    "lint": "tsdx lint",
+    "lint": "tsdx lint src",
     "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
     "react": ">=16"
@@ -67,5 +68,14 @@
     "tsdx": "0.14.1",
     "tslib": "2.8.0",
     "typescript": "5.6.3"
-  }
+  },
+  "keywords": [
+    "react",
+    "typescript",
+    "state-management",
+    "tabs",
+    "synchronization",
+    "broadcast-channel"
+  ],
+  "description": "A lightweight React library for synchronizing state across browser tabs in real-time"
 }


### PR DESCRIPTION
This pull request includes significant updates to the `README.md` file, changes to dependencies and scripts in `package.json`, and minor updates to `example/package.json`. The most important changes include a comprehensive rewrite of the `README.md` to reflect the new library features, updating Node.js version requirements, and adding keywords and descriptions to `package.json`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R150): Completely rewritten to describe the new `Tab State Manager` library, including installation instructions, core concepts, API reference, and best practices.

Dependency and script updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R23): Updated Node.js version requirement to `>=18`, added a `prepublishOnly` script, and included new keywords and description for the package. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R23) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L70-R80)
* [`example/package.json`](diffhunk://#diff-a593fc14fdef41aaf092f774b92cb74bafeda3e9559f8ae4762374bf4af80c92L11-R22): Pinned dependency versions to specific versions instead of using caret (`^`) ranges.

Closes #6 